### PR TITLE
Fix the options for 'file' command on Mac OS X.

### DIFF
--- a/mime-types.lisp
+++ b/mime-types.lisp
@@ -67,7 +67,9 @@ MIME-TYPE FILE-EXTENSION*"
 If the file does not exist or the platform is not unix, NIL is returned."
   #+unix
   (when (probe-file pathname)
-    (let ((output (uiop:run-program (list "file" "-bi" (uiop:native-namestring pathname)) :output :string)))
+    (let ((output (uiop:run-program (list "file" #+darwin "-bI" #-darwin "-bi"
+                                                 (uiop:native-namestring pathname))
+                                    :output :string)))
       (subseq output 0 (position #\; output))))
   #-unix
   NIL)


### PR DESCRIPTION
Mac OS's `file` command is a little bit different from others if the file specified is a regular file.

```
$ file -bi test.lisp
regular file

$ file -bI test.lisp
text/x-lisp; charset=us-ascii

$ file -b --mime-type test.lisp
text/x-lisp
```

Here's the `man` describing those options:

```
     -i      If the file is a regular file, do not classify its contents.

     -I, --mime
             Causes the file command to output mime type strings rather than the more traditional human readable ones. Thus it may say `text/plain; charset=us-ascii' rather than `ASCII text'.  In order for this
             option to work, file changes the way it handles files recognized by the command itself (such as many of the text file types, directories etc), and makes use of an alternative `magic' file.  (See the
             FILES section, below).

     --mime-type, --mime-encoding
             Like -I, but print only the specified element(s).
```

I've also checked it on FreeBSD, but the issue causes only on Mac OS.