### PR TITLE
Fix char reading loop

### DIFF
--- a/mime-types.lisp
+++ b/mime-types.lisp
@@ -72,7 +72,7 @@ If the file does not exist or the platform is not unix, NIL is returned."
                                     :output :string)))
       (with-output-to-string (mime)
         (loop for c across output
-              for char = (char-downcase char)
+              for char = (char-downcase c)
               ;; Allowed characters as per RFC6383
               while (find char "abcdefghijklmnopqrstuvwxyz0123456789!#$&-^_.+/")
               do (write-char char mime)))))


### PR DESCRIPTION
I guess there was a typo in loop.
Current version fails with 
```
#<THREAD "main thread" RUNNING {10005D05B3}>:
  The value
    NIL
  is not of type
    CHARACTER
  when binding CHAR
```