### PR TITLE
Skip/ignore comments

### DIFF
--- a/mime-types.lisp
+++ b/mime-types.lisp
@@ -48,6 +48,11 @@ If none can be found, an error is signalled."
     (when start (push (subseq line start) tokens))
     (nreverse tokens)))
 
+(defun valid-name-p (name)
+  "According to RFC6838 type names MUST start with an alphanumeric character
+This also conveniently skips comments"
+  (and name (alphanumericp (elt name 0))))
+
 (defun build-mime-db (&optional (file (find-mime.types)))
   "Populates the *MIME-DB* with data gathered from the file.
 The file should have the following structure:
@@ -57,6 +62,7 @@ MIME-TYPE FILE-EXTENSION*"
     (loop for line = (read-line stream NIL)
           while line
           for tokens = (%read-tokens line)
+          when (valid-name-p (first tokens))
           do (dolist (ending (cdr tokens))
                (setf (gethash ending *mime-db*) (car tokens)))
              (setf (gethash (first tokens) *reverse-mime-db*) (second tokens)))))


### PR DESCRIPTION
Before comments weren't ignored, which led to all kinds of words having the mime-type `#` associated to it, for example on my system `(mimes:mime "test.IANA")` returned the `#` mime-type.

I first tried skipping everything past the # character, but according to RFC6838 it is a valid character for type names, they do have to start with an alphanumeric character though which, if enforced, ignores comments. This also fixes that prior issue and on my system now returns `application/octet-stream`.